### PR TITLE
fixed sprite transformation setting while converting.

### DIFF
--- a/src/ssmit/FlashMovieClipConverter.as
+++ b/src/ssmit/FlashMovieClipConverter.as
@@ -73,7 +73,7 @@ package ssmit
 					}
 				}
 				convertedObject = convertedContainer;
-				convertedObject.transformationMatrix.copyFrom( displayObject.transform.matrix );
+				convertedObject.transformationMatrix = displayObject.transform.matrix.clone();
 				convertedObject.x = displayObject.x;
 				convertedObject.y = displayObject.y;
 			}


### PR DESCRIPTION
future transformationMatrix cloning should use matrix.clone() instead of matrix.copyFrom(), as copyFrom does not trigger starling display object transformationMatrix setter, which actually does all the transformation inside.
