### PR TITLE
using getBounds instead of getRect

### DIFF
--- a/src/ssmit/FlashMovieClipConverter.as
+++ b/src/ssmit/FlashMovieClipConverter.as
@@ -104,7 +104,7 @@ package ssmit
 					image.setTexCoords( 3, new Point( rightTC, bottomTC ) );
 					
 					// Textures don't have offsets, so the image must be translated to compensate.
-					var objectRect:Rectangle = displayObject.getRect( displayObject );
+					var objectRect:Rectangle = displayObject.getBounds( displayObject );
 					image.x = displayObject.x + objectRect.left;
 					image.y = displayObject.y + objectRect.top;
 					

--- a/src/ssmit/FlashMovieClipExporter.as
+++ b/src/ssmit/FlashMovieClipExporter.as
@@ -122,7 +122,7 @@ package ssmit
 					
 					var bitmapInfo:BitmapInfo = _textureList.getBitmapInfoFromDisplayObject( displayObject ); 
 					
-					var objectRect:Rectangle = displayObject.getRect( displayObject );
+					var objectRect:Rectangle = displayObject.getBounds( displayObject );
 					var imagePosX:Number = displayObject.x + objectRect.left;
 					var imagePosY:Number = displayObject.y + objectRect.top;
 					

--- a/src/ssmit/FrameData.as
+++ b/src/ssmit/FrameData.as
@@ -84,7 +84,7 @@ package ssmit
 					if( child is Shape || child is Bitmap )
 					{
 						// Child will be converted to a texture, compensate with offset.
-						var childRect:Rectangle = child.getRect( child );
+						var childRect:Rectangle = child.getBounds( child );
 						objectFrameData.transformationMatrix.tx += childRect.left;
 						objectFrameData.transformationMatrix.ty += childRect.top;
 					}

--- a/src/ssmit/TextureList.as
+++ b/src/ssmit/TextureList.as
@@ -37,7 +37,7 @@ package ssmit
 		internal function getBitmapInfoFromDisplayObject( displayObject:DisplayObject ) : BitmapInfo
 		{
 			// Capture the shape into a BitmapData.
-			var shapeRect:Rectangle = displayObject.getRect( displayObject );
+			var shapeRect:Rectangle = displayObject.getBounds( displayObject );
 			var matrix:Matrix = new Matrix();
 			matrix.translate( (-shapeRect.left) + PADDING, (-shapeRect.top) + PADDING );
 			var bitmapData:BitmapData = new BitmapData( Math.ceil(displayObject.width) + (PADDING*2), Math.ceil(displayObject.height) + (PADDING*2), true, 0x00000000 );	// Assume transparency on everything.


### PR DESCRIPTION
getRect sometimes disregards some shapes borders, resulting in textures cutted from edges.
